### PR TITLE
Enable multi-arch build for driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ If you want to use images you built locally for installation, edit all files und
 - To build the CSI driver, execute `make`.
 - To build the *synocli* dev tool, execute `make synocli`. The output binary will be at `bin/synocli`.
 - To run unit tests, execute `make test`.
-- To build a docker image, run `./scripts/deploy.sh build`.
- Afterwards, run `docker images` to check the newly created image.
+- To build a multi-arch docker image (amd64 and arm64), run `./scripts/deploy.sh build`. This command uses Docker Buildx under the hood.
+  Afterwards, run `docker images` to check the newly created image.
 
 ### Installation
 

--- a/build.sh
+++ b/build.sh
@@ -5,4 +5,5 @@ echo "src path=""$SOURCE_PATH"
 cd "$SOURCE_PATH" || exit
 # Do docker build
 make
-make docker-build
+make docker-build-multiarch
+


### PR DESCRIPTION
## Summary
- build Docker image for amd64 and arm64 platforms
- document the multi-arch build step in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c6dcbd3a883229b9c84f24aa868f8